### PR TITLE
DDL과 API 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,18 @@ _ _ _
 
 | API | Description | CRUD |
 |--------|--------|--------|
-| (posts) POST <br> /posts/{query}{source} | <ul><li>Crawl posts from the {source} with the {query}.</li><li>Parse the posts into sentences and morphemes.</li><li>Store all the results into the database.</li></ul>| <strong>C</strong> <ul><li>posts</li><li>sentences</li><li>words</li><li>entence_word_relations</li></ul>|
-| (posts) GET <br> /posts/{query} | <ul><li>Collect the posts related to the {query} from the database.</li></ul> | <strong>R</strong><ul><li>posts</li><li>sentences</li></ul> |
-| (posts) DELETE <br> /posts/{query} | <ul><li>Delete the posts related to the {query} from the database.</li></ul> | <strong>D</strong><ul><li>posts</li><li>sentences</li><li>sentence_word_relations</li></ul> |
-| (rulesets) POST <br> /rulesets/{name} | <ul><li>Create new ruleset.</li><li>Which is a kind of package of rules.</li></ul> | <strong>C</strong><ul><li>rulesets</li></ul> |
-| (rulesets) GET <br> /rulesets | <ul><li>Get all the rulesets from the database.</li></ul> | <strong>R</strong><ul><li>rulesets</li></ul> |
-| (rulesets) PUT <br> /rulesets/{id}{new_name} | <ul><li>Change the name of the ruleset.</li></ul> | <strong>U</strong><ul><li>rulesets</li></ul> |
-| (rulesets) DELETE <br> /rulesets/{id} | <ul><li>Delete the ruleset and realted rules.</li></ul> | <strong>D</strong><ul><li>rulesets</li><li>rules</li><li>rule_word_relations</li></ul> |
-| (rules) POST <br> /rulesets/{id}/rules/{fulltext} | <ul><li>Create new rule in the {ruleset}.</li><li>Parse the {fulltext} into morphemes.</li><li>Store the unregistered morphems into words table.</li><li>Get morphemes of the fulltext after parsing.</ul> | <strong>C</strong><ul><li>rules</li><li>words</li></ul> |
-| (rules) POST <br> /ruleset/{id}/words/{words} | <ul><li>Create an actual rule, combination of words.</li></ul> | <strong>C</strong><ul><li>rule_word_relations</li></ul> |
-| (rules) GET <br> /rulesets/{id} | <ul><li>Get rules of the selected rulset.</li></ul> | <strong>R</strong><ul><li>rulesets</li><li>rules</li></ul> |
-| (rules) PUT <br> /rules/{id}/words/{words} | <ul><li>Change the rule, combination of words.</li></ul> | <strong>R</strong><ul><li>rule_word_relations</li></ul> |
-| (rules) DELETE <br> /rules/{id} | <ul><li>Delete the rule, either fulltext and combination of words.</li></ul> | <strong>D</strong><ul><li>rules</li><li>rule_word_relations</li></ul> |
+| (topics) GET <br> /topics/ | <ul><li>Get all topics from the database.</li></ul> | <strong>R</strong><ul><li>topics</li></ul> |
+| (sources) GET <br> /sources/ | <ul><li>Get all sources from the database.</li></ul> | <strong>R</strong><ul><li>sources</li></ul> |
+| (rulesets) POST <br> /rulesets/{topic_id}/{ruleset_seq}/{name} | <ul><li>Create new ruleset.</li><li>Which is a kind of package of rules.</li></ul> | <strong>C</strong><ul><li>rulesets</li></ul> |
+| (rulesets) GET <br> /rulesets/{topic_id} | <ul><li>Get all the rulesets from the database.</li></ul> | <strong>R</strong><ul><li>rulesets</li></ul> |
+| (rulesets) PUT <br> /rulesets/{topic_id}/{ruleset_seq}/{new_name} | <ul><li>Change the name of the ruleset.</li></ul> | <strong>U</strong><ul><li>rulesets</li></ul> |
+| (rulesets) DELETE <br> /rulesets/{topic_id}/{ruleset_seq} | <ul><li>Delete the ruleset and its realted rules.</li></ul> | <strong>D</strong><ul><li>rulesets</li><li>rules</li><li>rule_word_relations</li></ul> |
+| (words) POST <br> /words/{fulltext} | <ul><li>Parse the {fulltext} into morphemes.</li><li>Store the unregistered morphems into words table.</li><li>Get morphemes of the fulltext after parsing.</ul> | <strong>C</strong><ul><li>words</li></ul> |
+| (rules) POST <br> /rules/{topic_id}/{ruleset_seq}/{fulltext}/{word_ids} | <ul><li>Create an actual rule, combination of words.</li></ul> | <strong>C</strong><ul><li>rules</li><li>rule_word_relations</li></ul> |
+| (rules) GET <br> /rules/{topic_id}/{ruleset_seq} | <ul><li>Get rules of the selected rulset.</li></ul> | <strong>R</strong><ul><li>rules</li><li>(rule_word_relations?)</li></ul> |
+| (rules) GET <br> /rules/{rule_id} | <ul><li>Get specific rule.</li></ul> | <strong>R</strong><ul><li>rules</li><li>rule_word_relations</li></ul> |
+| (rules) PUT <br> /rules/{rule_id}/{word_ids} | <ul><li>Change the rule, combination of words.</li></ul> | <strong>U</strong><ul><li>rule_word_relations</li></ul> |
+| (rules) DELETE <br> /rules/{rule_id} | <ul><li>Delete the rule, either fulltext and combination of words.</li></ul> | <strong>D</strong><ul><li>rules</li><li>rule_word_relations</li></ul> |
 
 
 

--- a/schema.sql
+++ b/schema.sql
@@ -6,47 +6,81 @@ drop table if exists words;
 drop table if exists sentences;
 drop table if exists posts;
 
-create table posts(
-    _id int primary key auto_increment,
-    url varchar(255) character set utf8mb4,
-    title varchar(255) character set utf8mb4
-);
-create table words(
-    _id int primary key auto_increment,
-    word varchar(255) character set utf8mb4
-);
-create table rulesets(
-    _id int primary key auto_increment,
-    name varchar(255) character set utf8mb4
+/* [static] topic of an analysis */
+CREATE TABLE topics(
+    _id INT PRIMARY KEY AUTO_INCREMENT,
+    name VARCHAR(255) CHARACTER SET UTF8MB4
 );
 
-create table rules(
-    _id int primary key auto_increment,
-    ruleset_id int,
-    full_text text character set utf8mb4,
-    foreign key (ruleset_id) references rulesets(_id)
+/* [static] We will use only few sources. Twitter / Instagram / YouTube / NewsInWeb. */
+CREATE TABLE sources(
+    _id INT PRIMARY KEY AUTO_INCREMENT,
+    name VARCHAR(255) CHARACTER SET UTF8MB4
 );
-create table sentences(
-    post_id int,
-    sentence_seq int,
-    full_text text character set utf8mb4,
-    primary key (post_id, sentence_seq),
-    foreign key (post_id) references posts(_id)
+
+/* vocab */
+CREATE TABLE words(
+    _id INT PRIMARY KEY AUTO_INCREMENT,
+    word VARCHAR(128) CHARACTER SET UTF8MB4,
+    UNIQUE KEY `idx_word` (`word`) USING HASH
 );
-create table sentence_word_relations(
-    post_id int,
-    sentence_seq int,
-    word_seq int,
-    word_id int,
-    primary key (post_id, sentence_seq, word_seq),
-    foreign key (post_id, sentence_seq) references sentences(post_id, sentence_seq),
-    foreign key (word_id) references words(_id)
+
+/* each post in a topic, crawled from one of the sources */
+CREATE TABLE posts(
+    _id INT PRIMARY KEY AUTO_INCREMENT,
+    topic_id INT,
+    source_id INT,
+    title VARCHAR(255) CHARACTER SET UTF8MB4,
+    url TEXT CHARACTER SET UTF8MB4,
+    FOREIGN KEY (topic_id) REFERENCES topics(_id),
+    FOREIGN KEY (source_id) REFERENCES sources(_id)
 );
-create table rule_word_relations(
-    rule_id int,
-    word_seq int,
-    word_id int,
-    primary key (rule_id, word_seq),
-    foreign key (rule_id) references rules(_id),
-    foreign key (word_id) references words(_id)
+
+/* each sentence in a post. Since sentence is the base unit for grading the rules, we decided to create this table */
+CREATE TABLE sentences(
+    post_id INT,
+    sentence_seq INT,
+    full_text TEXT CHARACTER SET UTF8MB4,
+    PRIMARY KEY (post_id, sentence_seq),
+    FOREIGN KEY (post_id) REFERENCES posts(_id)
+);
+
+/* store the word orders */
+CREATE TABLE sentence_word_relations(
+    post_id INT,
+    sentence_seq INT,
+    word_seq INT,
+    word_id INT,
+    PRIMARY KEY (post_id, sentence_seq, word_seq),
+    FOREIGN KEY (post_id, sentence_seq) REFERENCES sentences(post_id, sentence_seq),
+    FOREIGN KEY (word_id) REFERENCES words(_id)
+);
+
+/* [static] each topic has 4~6 rulesets. (most of them has 5 categories) */
+CREATE TABLE rulesets(
+    topic_id INT,
+    category_seq INT,   /* since it would be weird to see '103th ruleset' in screen, I changed this to 'category_number' */
+    name VARCHAR(255) CHARACTER SET UTF8MB4,
+    PRIMARY KEY (topic_id, category_seq),
+    FOREIGN KEY (topic_id) REFERENCES topics(_id)
+);
+
+/* each rules in a ruleset */
+CREATE TABLE rules(
+    _id INT PRIMARY KEY AUTO_INCREMENT,
+    topic_id INT,
+    category_seq INT,
+    full_text TEXT CHARACTER SET UTF8MB4,
+    INDEX `idx_topicid_categoryseq` (`topic_id` ASC, `category_seq` ASC),
+    FOREIGN KEY (topic_id, category_seq) REFERENCES rulesets(topic_id, category_seq)
+);
+
+/* store the word orders */
+CREATE TABLE rule_word_relations(
+    rule_id INT,
+    word_seq INT,
+    word_id INT,
+    PRIMARY KEY (rule_id, word_seq),
+    FOREIGN KEY (rule_id) REFERENCES rules(_id),
+    FOREIGN KEY (word_id) REFERENCES words(_id)
 );


### PR DESCRIPTION
각각 파일의 바뀐 부분은 각 commit에 적어두었어요.
이정도 작업하고, 나머지 부분은 직접 DBMS 에 붙어서 입력해줘도 되지 않을까 싶어요.
(readme에서의 api call format은 그냥 임시로 작성한거라, 보고 원하시는대로 변경하셔도 좋을것 같습니다.
일부러 naming을 앞으로 빼두었는데, 이는 단지 routing을 용이하게 처리하기 위함입니다.)
- post 관련된 api가 일부 없어졌는데.. 그 이유는, 나중에 crawler돌리면, 성민님이 생각한대로 api call / parsing이 아니라 json같은 형태로 data가 떨어질 확률이 높기 때문입니다.
- 그런데.. 생각해보니 (re)calculate 하는 api를 빼먹은것 같네요.
